### PR TITLE
Tweak dialogs to better fit material design spec.

### DIFF
--- a/src/app/recipes/recipe-list/delete-recipe-dialog.component.ts
+++ b/src/app/recipes/recipe-list/delete-recipe-dialog.component.ts
@@ -7,10 +7,15 @@ import { MdDialogRef, MD_DIALOG_DATA }  from "@angular/material";
     <h2 md-dialog-title class="mat-h2">Delete Recipe</h2>
     <md-dialog-content class="mat-body-1">Are you sure you want to delete your {{recipeName}} recipe?</md-dialog-content>
     <md-dialog-actions class="button-container">
-      <button md-button [md-dialog-close]="false">Cancel</button>
       <button md-button [md-dialog-close]="true">Delete</button>
+      <button md-button [md-dialog-close]="false">Cancel</button>
     </md-dialog-actions>
-    `
+    `,
+    styles: [`
+      .button-container {
+        flex-direction: row-reverse;
+      }
+      `]
 })
 export class DeleteRecipeDialogComponent {
   constructor(

--- a/src/app/recipes/recipe-list/delete-recipe-dialog.component.ts
+++ b/src/app/recipes/recipe-list/delete-recipe-dialog.component.ts
@@ -7,15 +7,10 @@ import { MdDialogRef } from "@angular/material";
     <h2 md-dialog-title class="mat-h2">Delete Recipe</h2>
     <md-dialog-content class="mat-body-1">Are you sure you want to delete this recipe?</md-dialog-content>
     <md-dialog-actions class="button-container">
-      <button md-button [md-dialog-close]="false">No</button>
-      <span class="expand"></span>
-      <button md-button [md-dialog-close]="true">Yes</button>
+      <button md-button [md-dialog-close]="false">Cancel</button>
+      <button md-button [md-dialog-close]="true">Delete</button>
     </md-dialog-actions>
-    `,
-  styles: [`
-    .button-container { display: flex }
-    .expand { flex: 1 auto }
-    `]
+    `
 })
 export class DeleteRecipeDialogComponent {
   constructor(public dialogRef: MdDialogRef<DeleteRecipeDialogComponent>) {}

--- a/src/app/recipes/recipe-list/delete-recipe-dialog.component.ts
+++ b/src/app/recipes/recipe-list/delete-recipe-dialog.component.ts
@@ -1,11 +1,11 @@
-import { Component }   from "@angular/core";
-import { MdDialogRef } from "@angular/material";
+import { Component, Inject }            from "@angular/core";
+import { MdDialogRef, MD_DIALOG_DATA }  from "@angular/material";
 
 @Component({
   selector: "delete-recipe-dialog",
   template: `
     <h2 md-dialog-title class="mat-h2">Delete Recipe</h2>
-    <md-dialog-content class="mat-body-1">Are you sure you want to delete this recipe?</md-dialog-content>
+    <md-dialog-content class="mat-body-1">Are you sure you want to delete your {{recipeName}} recipe?</md-dialog-content>
     <md-dialog-actions class="button-container">
       <button md-button [md-dialog-close]="false">Cancel</button>
       <button md-button [md-dialog-close]="true">Delete</button>
@@ -13,5 +13,8 @@ import { MdDialogRef } from "@angular/material";
     `
 })
 export class DeleteRecipeDialogComponent {
-  constructor(public dialogRef: MdDialogRef<DeleteRecipeDialogComponent>) {}
+  constructor(
+    @Inject(MD_DIALOG_DATA) public recipeName: string,
+    public dialogRef: MdDialogRef<DeleteRecipeDialogComponent>
+  ) {}
 }

--- a/src/app/recipes/recipe-list/recipe-list.component.html
+++ b/src/app/recipes/recipe-list/recipe-list.component.html
@@ -5,7 +5,7 @@
     <a md-line
       [routerLink]="['/recipe', recipe.$key]">{{recipe.name}}</a>
     <button md-icon-button
-      (click)="deleteRecipe(recipe.$key)"
+      (click)="deleteRecipe(recipe)"
       type="button"
       class="delete-recipe">
       <md-icon class="delete-recipe-icon">delete</md-icon>

--- a/src/app/recipes/recipe-list/recipe-list.component.ts
+++ b/src/app/recipes/recipe-list/recipe-list.component.ts
@@ -37,17 +37,17 @@ export class RecipeListComponent {
 
   // Open the delete recipe dialog and retrieve the response
   //TODO:Clean up the promise bit. There must be a better way...
-  private openDeleteRecipeDialog(): Promise<boolean> {
-    return this.dialog.open(DeleteRecipeDialogComponent)
-      .afterClosed()
-      .toPromise();
+  private openDeleteRecipeDialog(recipeName: string): Promise<boolean> {
+    return this.dialog.open(DeleteRecipeDialogComponent, {
+      data: recipeName
+    }).afterClosed().toPromise();
   }
 
   // Delete a recipe
-  async deleteRecipe(id: string): Promise<void> {
-    let confirmation = await this.openDeleteRecipeDialog();
+  async deleteRecipe(recipe: Recipe): Promise<void> {
+    let confirmation = await this.openDeleteRecipeDialog(recipe.name);
 
     if (confirmation)
-      await this.service.deleteRecipe(id);
+      await this.service.deleteRecipe(recipe.$key);
   }
 }

--- a/src/app/user/local-sign-in-dialog.component.ts
+++ b/src/app/user/local-sign-in-dialog.component.ts
@@ -17,15 +17,16 @@ import { MdDialogRef }  from "@angular/material";
           name="password" />
       </md-input-container>
     </md-dialog-content>
-    <md-dialog-actions class="button-container">
-      <button md-button
-        [md-dialog-close]="false">Cancel</button>
+    <md-dialog-actions class="actions">
       <button md-button
         [md-dialog-close]="{email:email.value, password:password.value}">Sign In</button>
+      <button md-button
+        [md-dialog-close]="false">Cancel</button>
     </md-dialog-actions>
     `,
   styles: [`
     .field { display: block }
+    .actions { flex-direction: row-reverse }
     `]
 })
 export class LocalSignInDialogComponent {

--- a/src/app/user/local-sign-in-dialog.component.ts
+++ b/src/app/user/local-sign-in-dialog.component.ts
@@ -16,25 +16,16 @@ import { MdDialogRef }  from "@angular/material";
           type="password" placeholder="password"
           name="password" />
       </md-input-container>
-      <md-input-container class="field">
-        <input mdInput #passwordConfirm
-          type="password" placeholder="confirm password"
-          name="passwordConfirm" />
-      </md-input-container>
     </md-dialog-content>
     <md-dialog-actions class="button-container">
       <button md-button
-        [disabled]="password.value !== passwordConfirm.value"
-        [md-dialog-close]="{email:email.value, password:password.value}">Sign In</button>
-      <span class="expand"></span>
-      <button md-button
         [md-dialog-close]="false">Cancel</button>
+      <button md-button
+        [md-dialog-close]="{email:email.value, password:password.value}">Sign In</button>
     </md-dialog-actions>
     `,
   styles: [`
     .field { display: block }
-    .button-container { display: flex }
-    .expand { flex: 1 auto }
     `]
 })
 export class LocalSignInDialogComponent {

--- a/src/app/user/local-sign-up-dialog.component.ts
+++ b/src/app/user/local-sign-up-dialog.component.ts
@@ -22,18 +22,17 @@ import { MdDialogRef }  from "@angular/material";
           name="passwordConfirm" />
       </md-input-container>
     </md-dialog-content>
-    <md-dialog-actions>
-      <button md-button
-        [md-dialog-close]="false">Cancel</button>
+    <md-dialog-actions class="actions">
       <button md-button
         [disabled]="password.value !== passwordConfirm.value"
         [md-dialog-close]="{email:email.value, password:password.value}">Sign Up</button>
+      <button md-button
+        [md-dialog-close]="false">Cancel</button>
     </md-dialog-actions>
     `,
   styles: [`
     .field { display: block }
-    .button-container { display: flex }
-    .expand { flex: 1 auto }
+    .actions { flex-direction: row-reverse }
     `]
 })
 export class LocalSignUpDialogComponent {

--- a/src/app/user/local-sign-up-dialog.component.ts
+++ b/src/app/user/local-sign-up-dialog.component.ts
@@ -16,13 +16,18 @@ import { MdDialogRef }  from "@angular/material";
           type="password" placeholder="password"
           name="password" />
       </md-input-container>
+      <md-input-container class="field">
+        <input mdInput #passwordConfirm
+          type="password" placeholder="confirm password"
+          name="passwordConfirm" />
+      </md-input-container>
     </md-dialog-content>
-    <md-dialog-actions class="button-container">
-      <button md-button
-        [md-dialog-close]="{email:email.value, password:password.value}">Sign Up</button>
-      <span class="expand"></span>
+    <md-dialog-actions>
       <button md-button
         [md-dialog-close]="false">Cancel</button>
+      <button md-button
+        [disabled]="password.value !== passwordConfirm.value"
+        [md-dialog-close]="{email:email.value, password:password.value}">Sign Up</button>
     </md-dialog-actions>
     `,
   styles: [`

--- a/src/app/user/sign-in-landing-dialog.component.ts
+++ b/src/app/user/sign-in-landing-dialog.component.ts
@@ -4,17 +4,14 @@ import { MdDialogRef } from "@angular/material";
 @Component({
   selector: "sign-in-landing-dialog",
   template: `
-    <h2 md-dialog-title class="mat-h2">Select Sign In Method</h2>
+    <h2 md-dialog-title class="mat-h2">Sign In</h2>
     <md-dialog-content class="method-container">
-      <p class="mat-body-1">
-        How do you want to sign in?
-      </p>
       <button md-button
         [md-dialog-close]="'google'"
-        class="method">Sign In With Google</button>
+        class="method">With Google</button>
       <button md-button
-        [md-dialog-close]="'local'"
-        class="method">Sign In</button>
+        [md-dialog-close]="'email'"
+        class="method">With Email</button>
       <button md-button
         [md-dialog-close]="'sign-up'"
         class="method">Sign Up</button>

--- a/src/app/user/user.service.ts
+++ b/src/app/user/user.service.ts
@@ -49,7 +49,7 @@ export class UserService {
           case "sign-up":
             this.signUpWithEmailAndPasswordPopup();
             break;
-          case "local":
+          case "email":
             this.signInWithEmailAndPasswordPopup();
             break;
           case "google":


### PR DESCRIPTION
Tweak the dialogs to better fit material design specifications in terms of how action buttons should be labeled. Also removed the space between action buttons that forced them to exist on different sides of the dialog.

Additionally, fixed a problem where the extra password field was in the sign _in_ dialog instead of the sign _up_ dialog.