### PR TITLE
Change build target to es5, allowing production build.

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,7 @@
     "moduleResolution": "node",
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
-    "target": "es6",
+    "target": "es5",
     "typeRoots": [
       "node_modules/@types"
     ],


### PR DESCRIPTION
This fixes #7 by changing the typescript build target to es5. This quite possibly breaks something else, as I don't really understand the full impacts of the build target.

Weeeeee.