### PR TITLE
Guard against leaving recipe-detail view without saving changes.

### DIFF
--- a/src/app/recipes/recipe-detail/confirm-nav-dialog.component.ts
+++ b/src/app/recipes/recipe-detail/confirm-nav-dialog.component.ts
@@ -1,0 +1,28 @@
+import { Component, Inject }            from "@angular/core";
+import { MdDialogRef, MD_DIALOG_DATA }  from "@angular/material";
+
+@Component({
+  selector: "confirm-nav-dialog",
+  template: `
+    <h2 md-dialog-title class="mat-h2">Leave this page?</h2>
+    <md-dialog-content class="mat-body-1">Your changes haven't been saved.</md-dialog-content>
+    <md-dialog-actions class="button-container">
+      <button md-button
+        [md-dialog-close]="'save'"
+        [disabled]="!savable">Save and leave</button>
+      <button md-button [md-dialog-close]="'cancel'">Go back</button>
+      <button md-button [md-dialog-close]="'leave'">Leave without saving</button>
+    </md-dialog-actions>
+    `,
+  styles: [`
+    .button-container {
+      flex-direction: row-reverse;
+    }
+    `]
+})
+export class ConfirmNavDialogComponent {
+  constructor(
+    @Inject(MD_DIALOG_DATA) public savable: boolean,
+    public dialogRef: MdDialogRef<ConfirmNavDialogComponent>
+  ) {}
+}

--- a/src/app/recipes/recipe-detail/recipe-detail.component.ts
+++ b/src/app/recipes/recipe-detail/recipe-detail.component.ts
@@ -1,8 +1,9 @@
 //import { Observable }                       from "rxjs/Observable";
 import 'rxjs/add/operator/switchMap';
 
-import { Component, OnInit }                from '@angular/core';
+import { Component, OnInit, ViewChild }     from '@angular/core';
 import { Router, ActivatedRoute, ParamMap } from '@angular/router';
+import { NgForm }                           from "@angular/forms";
 
 import { Recipe, recipeUtil }               from "../recipe";
 import { RecipeService }                    from "../recipe.service";
@@ -13,6 +14,8 @@ import { RecipeService }                    from "../recipe.service";
   styleUrls: [ "./recipe-detail.component.sass" ]
 })
 export class RecipeDetailComponent {
+  @ViewChild("recipeForm") form: NgForm;
+
   recipe: Recipe;
 
   constructor(
@@ -42,8 +45,9 @@ export class RecipeDetailComponent {
   }
 
   // Save the recipe
-  save(): void {
-    this.service.saveRecipe(this.recipe);
+  async save(): Promise<void> {
+    await this.service.saveRecipe(this.recipe);
+    this.form.form.markAsPristine();
   }
 
   ngOnInit(): void {

--- a/src/app/recipes/recipe-detail/recipe-saved-guard.service.ts
+++ b/src/app/recipes/recipe-detail/recipe-saved-guard.service.ts
@@ -1,0 +1,51 @@
+import 'rxjs/add/operator/toPromise';
+
+import { Injectable }                 from "@angular/core";
+import { MdDialog }                   from "@angular/material";
+import {
+  CanDeactivate,
+  ActivatedRouteSnapshot,
+  RouterStateSnapshot
+}                                     from '@angular/router';
+
+import { RecipeDetailComponent }      from "./recipe-detail.component";
+import { ConfirmNavDialogComponent }  from "./confirm-nav-dialog.component";
+
+@Injectable()
+export class RecipeSavedGuard implements CanDeactivate<RecipeDetailComponent> {
+  constructor(
+    private dialog: MdDialog
+  ) {}
+
+  async prompt(savable: boolean): Promise<string> {
+    return this.dialog.open(ConfirmNavDialogComponent, {
+      data: savable
+    })
+      .afterClosed()
+      .toPromise();
+  }
+
+  async canDeactivate(
+    component: RecipeDetailComponent,
+    route: ActivatedRouteSnapshot,
+    state: RouterStateSnapshot
+  ): Promise<boolean> {
+    if (component.form.pristine) return true;
+
+    let savable = component.form.valid;
+    console.log(savable);
+    let res = await this.prompt(savable);
+
+    switch (res) {
+      case "save":
+        await component.save();
+        return true;
+      case "leave":
+        return true;
+      case "cancel":
+        return false;
+      default:
+        return false;
+    }
+  }
+}

--- a/src/app/recipes/recipes-routing.module.ts
+++ b/src/app/recipes/recipes-routing.module.ts
@@ -6,6 +6,7 @@ import { RecipeDetailComponent }  from "./recipe-detail/recipe-detail.component"
 
 import { UserService }            from "../user/user.service";
 import { RequireUserGuard }       from "../user/require-user-guard.service";
+import { RecipeSavedGuard }       from "./recipe-detail/recipe-saved-guard.service";
 
 const recipesRoutes: Routes = [
   {
@@ -13,7 +14,11 @@ const recipesRoutes: Routes = [
     canActivateChild: [RequireUserGuard],
     children: [
       { path: "", component: RecipeListComponent },
-      { path: ":id", component: RecipeDetailComponent }
+      {
+        path: ":id",
+        component: RecipeDetailComponent,
+        canDeactivate: [RecipeSavedGuard]
+      }
     ]
   }
 ];
@@ -26,7 +31,8 @@ const recipesRoutes: Routes = [
     RouterModule
   ],
   providers: [
-    RequireUserGuard
+    RequireUserGuard,
+    RecipeSavedGuard
   ]
 })
 export class RecipesRoutingModule {}

--- a/src/app/recipes/recipes.module.ts
+++ b/src/app/recipes/recipes.module.ts
@@ -6,6 +6,7 @@ import { FormsModule }                  from "@angular/forms";
 import { RouterModule }                 from "@angular/router";
 
 import { RecipeDetailComponent }        from "./recipe-detail/recipe-detail.component";
+import { ConfirmNavDialogComponent }    from "./recipe-detail/confirm-nav-dialog.component";
 import { RecipeListComponent }          from "./recipe-list/recipe-list.component";
 import { DeleteRecipeDialogComponent }  from "./recipe-list/delete-recipe-dialog.component";
 
@@ -26,10 +27,12 @@ import { RecipesRoutingModule }         from "./recipes-routing.module";
   declarations: [
     RecipeDetailComponent,
     RecipeListComponent,
-    DeleteRecipeDialogComponent
+    DeleteRecipeDialogComponent,
+    ConfirmNavDialogComponent
   ],
   entryComponents: [
-    DeleteRecipeDialogComponent
+    DeleteRecipeDialogComponent,
+    ConfirmNavDialogComponent
   ],
   providers: [
     UserService,


### PR DESCRIPTION
When leaving the recipe-detail view with unsaved changes, users are now
prompted to either leave without saving, save and leave, or cancel the
navigation.