### PR TITLE
Recipe data now resolves and redirects to the list on error.

### DIFF
--- a/src/app/recipes/recipe-detail/recipe-detail-resolver.service.ts
+++ b/src/app/recipes/recipe-detail/recipe-detail-resolver.service.ts
@@ -1,0 +1,39 @@
+import { Observable }       from "rxjs/Observable";
+import { BehaviorSubject }  from "rxjs/BehaviorSubject";
+import "rxjs/add/operator/toPromise";
+import "rxjs/add/operator/first";
+
+import { Injectable }       from "@angular/core";
+import {
+  Router, Resolve,
+  RouterStateSnapshot,
+  ActivatedRouteSnapshot
+}                           from '@angular/router';
+
+import { Recipe }           from "../recipe";
+import { RecipeService }    from "../recipe.service";
+import { UserService }      from "../../user/user.service";
+
+@Injectable()
+export class RecipeDetailResolver implements Resolve<BehaviorSubject<Recipe>> {
+  constructor(
+    private rs: RecipeService,
+    private router: Router
+  ) {}
+
+  async resolve(
+    route: ActivatedRouteSnapshot,
+    state: RouterStateSnapshot
+  ): Promise<BehaviorSubject<Recipe>> {
+    try {
+      let obs = this.rs.getRecipe(route.paramMap.get("id"));
+      let init = await obs.first().toPromise();
+      let sub = new BehaviorSubject(init);
+      obs.multicast(sub).connect();
+      return sub;
+    } catch (e) {
+      this.router.navigate(["/recipe"]);
+      return null;
+    }
+  }
+}

--- a/src/app/recipes/recipe-detail/recipe-detail.component.ts
+++ b/src/app/recipes/recipe-detail/recipe-detail.component.ts
@@ -51,11 +51,9 @@ export class RecipeDetailComponent {
   }
 
   ngOnInit(): void {
-    this.route.paramMap
-      .switchMap((params: ParamMap) =>
-        this.service.getRecipe(params.get("id")))
-      .subscribe(recipe => {
-        this.recipe = recipe;
+    this.route.data
+      .subscribe((data: any) => {
+        data.recipe.subscribe(recipe => this.recipe = recipe);
       });
   }
 }

--- a/src/app/recipes/recipes-routing.module.ts
+++ b/src/app/recipes/recipes-routing.module.ts
@@ -7,6 +7,7 @@ import { RecipeDetailComponent }  from "./recipe-detail/recipe-detail.component"
 import { UserService }            from "../user/user.service";
 import { RequireUserGuard }       from "../user/require-user-guard.service";
 import { RecipeSavedGuard }       from "./recipe-detail/recipe-saved-guard.service";
+import { RecipeDetailResolver }   from "./recipe-detail/recipe-detail-resolver.service";
 
 const recipesRoutes: Routes = [
   {
@@ -17,7 +18,8 @@ const recipesRoutes: Routes = [
       {
         path: ":id",
         component: RecipeDetailComponent,
-        canDeactivate: [RecipeSavedGuard]
+        canDeactivate: [RecipeSavedGuard],
+        resolve: { recipe: RecipeDetailResolver }
       }
     ]
   }
@@ -32,7 +34,8 @@ const recipesRoutes: Routes = [
   ],
   providers: [
     RequireUserGuard,
-    RecipeSavedGuard
+    RecipeSavedGuard,
+    RecipeDetailResolver
   ]
 })
 export class RecipesRoutingModule {}


### PR DESCRIPTION
When loading a recipe detail page, the recipe now resolves ahead of
time. If there is an error, it instead redirects to the recipe list
view. This means that errors caused by being unable to read a recipe
prevent loading.

This is a temporary fix; I need to figure out a better way of handling
it that uses the CanActivate guard somehow.