### PR TITLE
Fixed FAB positioning now works.

### DIFF
--- a/src/app/app.component.sass
+++ b/src/app/app.component.sass
@@ -15,5 +15,5 @@ app-toolbar
   flex-direction: column
   flex-grow: 1
 
-/deep/ .mat-sidenav-content
-  transform: none !important
+  /deep/ .mat-drawer-content
+    transform: none !important

--- a/src/app/recipes/recipe-list/recipe-list.component.sass
+++ b/src/app/recipes/recipe-list/recipe-list.component.sass
@@ -17,6 +17,6 @@
   +theme-list-icons(".recipe-item", ".delete-recipe")
 
 .new-recipe
-  position: absolute
+  position: fixed
   bottom: 10pt
   right: 10pt


### PR DESCRIPTION
Fixed FAB positioning now works inside the router-outlet.

I need to find a more permanent solution to this; having to muck about
with the internals of the md-sidebar is what caused this to break in the
first place. (A class name changed, which broke the transform override I
have in place.)